### PR TITLE
feat: add spec helper to link files

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'csv'
+require_relative 'games'
+require_relative 'teams'
+require './lib/stat_tracker'


### PR DESCRIPTION
added spec helper file. The other spec files do not yet have require 'spec_helper" added to them.